### PR TITLE
Resolve "#1 containerize libfec"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM alpine:3.20 AS build
 
 # Install necessary packages
-# TODO Document all we need to add here
 RUN apk add --no-cache build-base cmake
 
 # Set the working directory
@@ -19,10 +18,10 @@ RUN cmake -S . -B build && \
     cmake --install build
 
 # Release stage
-#FROM alpine:3.20
+FROM alpine:3.20
 
 # Copy the build artifacts from the build stage
-#COPY --from=build /usr/local /usr/local
+COPY --from=build /usr/local /usr/local
 
 # Set the entrypoint
 ENTRYPOINT ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM alpine:3.20 AS build
+
+# Install necessary packages
+# TODO Document all we need to add here
+RUN apk add --no-cache build-base cmake
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the source code into the container
+COPY . /app/libfec
+
+# Build LibFEC
+WORKDIR /app/libfec
+RUN cmake -S . -B build && \
+    cmake --build build && \
+    cmake --build build --target test_correctness && \
+    cmake --install build
+
+# Release stage
+#FROM alpine:3.20
+
+# Copy the build artifacts from the build stage
+#COPY --from=build /usr/local /usr/local
+
+# Set the entrypoint
+ENTRYPOINT ["/bin/sh"]
+

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Default values
+DEFAULT_IMAGE_NAME="libfec-alpine"
+DEFAULT_TAG="0.1.0"
+
+# Usage function to display help for the script
+usage() {
+  echo "Usage: $0 [-n <image-name>] [-t <tag>]"
+  exit 1
+}
+
+# Parse command-line arguments
+while getopts ":n:t:" opt; do
+  case ${opt} in
+    n )
+      IMAGE_NAME=$OPTARG
+      ;;
+    t )
+      TAG=$OPTARG
+      ;;
+    \? )
+      usage
+      ;;
+    : )
+      usage
+      ;;
+  esac
+done
+
+# Set defaults if not provided
+IMAGE_NAME=${IMAGE_NAME:-$DEFAULT_IMAGE_NAME}
+TAG=${TAG:-$DEFAULT_TAG}
+
+# Build and tag the Docker image
+docker build -t "${IMAGE_NAME}:${TAG}" .
+
+# Verify if the image was built successfully
+if [ $? -eq 0 ]; then
+  echo "Docker image ${IMAGE_NAME}:${TAG} built successfully."
+else
+  echo "Failed to build Docker image ${IMAGE_NAME}:${TAG}."
+  exit 1
+fi
+


### PR DESCRIPTION
Minimal container to encapsulate libfec. [`COPY --from` instruction](https://docs.docker.com/build/building/multi-stage/#use-an-external-image-as-a-stage) can be repeated in downstream Dockerfiles that want to incorporate libfec.

